### PR TITLE
performance optimizations

### DIFF
--- a/R/detect_coordinated_groups.R
+++ b/R/detect_coordinated_groups.R
@@ -99,6 +99,13 @@ do_detect_coordinated_groups <- function(x,
   # before they can be considered coordinated
   x <- x[, if (.N > min_repetition) .SD, by = id_user]
 
+  # --------------------------
+  # strings to factors
+  x[,
+     c('object_id', 'id_user', 'content_id') := lapply(.SD, as.factor),
+     .SDcols = c('object_id', 'id_user', 'content_id')]
+
+
   # ---------------------------
   # calculate time differences per group
 
@@ -113,6 +120,12 @@ do_detect_coordinated_groups <- function(x,
   if (min_repetition > 1) {
     result <- filter_min_repetition(x, result, min_repetition)
   }
+
+  # ----------------------------
+  # factors back to string
+  result[, c("object_id", "content_id", "content_id_y", "id_user", "id_user_y") := lapply(.SD, as.character),
+     .SDcols = c("object_id", "content_id", "content_id_y", "id_user", "id_user_y")]
+
 
   # ---------------------------
   # remove loops

--- a/R/reshape_tweets.r
+++ b/R/reshape_tweets.r
@@ -46,7 +46,7 @@ reshape_tweets <- function(
     drop_replies = TRUE,
     drop_hashtags = FALSE) {
     start <- tweet_id <- type <- referenced_tweet_id <- object_id <- id_user <-
-        text <- text_normalized <- domain <- NULL
+        text <- text_normalized <- domain <- content_id <- NULL
     if (!inherits(tweets, "list")) {
         stop("Provided data probably not preprocessed yet.")
     }
@@ -108,7 +108,9 @@ reshape_tweets <- function(
         )
 
         data.table::setnames(retweets, tweet_cols, output_cols)
-        data.table::setindex(retweets, object_id, id_user)
+        data.table::setindex(retweets, object_id)
+        data.table::setindex(retweets, id_user)
+        data.table::setindex(retweets, content_id)
 
         return(retweets)
     } else if (intent == "hashtags") {
@@ -125,7 +127,10 @@ reshape_tweets <- function(
         hashtags <- hashtags[, tweet_cols, with = FALSE]
 
         data.table::setnames(hashtags, tweet_cols, output_cols)
-        data.table::setindex(hashtags, object_id, id_user)
+        data.table::setindex(hashtags, object_id)
+        data.table::setindex(hashtags, id_user)
+        data.table::setindex(hashtags, content_id)
+
 
         return(hashtags)
     } else if (intent == "urls") {
@@ -152,7 +157,9 @@ reshape_tweets <- function(
         urls <- urls[, tweet_cols, with = FALSE]
 
         data.table::setnames(urls, tweet_cols, output_cols)
-        data.table::setindex(urls, object_id, id_user)
+        data.table::setindex(urls, object_id)
+        data.table::setindex(urls, id_user)
+        data.table::setindex(urls, content_id)
 
         return(urls)
     } else if (intent == "urls_domains") {
@@ -176,7 +183,9 @@ reshape_tweets <- function(
         domains <- domains[, tweet_cols, with = FALSE]
 
         data.table::setnames(domains, tweet_cols, output_cols)
-        data.table::setindex(domains, object_id, id_user)
+        data.table::setindex(domains, object_id)
+        data.table::setindex(domains, id_user)
+        data.table::setindex(domains, content_id)
 
         return(domains)
     } else if (intent == "cotweet") {
@@ -211,6 +220,7 @@ reshape_tweets <- function(
         data.table::setnames(cotweets, tweet_cols, output_cols)
         data.table::setindex(cotweets, object_id)
         data.table::setindex(cotweets, id_user)
+        data.table::setindex(cotweets, content_id)
 
         return(cotweets)
     } else {


### PR DESCRIPTION
There are some small changes that heavily impact memory usage:

1) the indices are set separately for each column in the "reshape" function (this is a minor tweak)
2) The coordination detection function now converts the id columns (object_id, id_user, content_id) to factors, then it runs the computations, and then transforms them back to character vectors. This has a large impact on memory utilization. Before the change, every string got multiplied in memory for each possible combination. This blows up memory when there is a very large number of possible pairs. Now with the factor conversion this does not happen anymore. This makes the function marginally slower though.

With this change I was able to run it on  a dataset with ~10 million tweets and a time window 120 seconds. The largest group had about 16000 members.
